### PR TITLE
기본 db를 h2로 변경한 PR 올립니다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
     // object storage
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.731'
+
+    // h2
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -101,19 +101,26 @@ tasks.withType(GenerateSwaggerUI).configureEach {
 
 tasks.register("copySwaggerUISample") {
     doLast {
+        def destinationDir
+
+        if ("${profile}" == 'local') {
+            destinationDir = "src/main/resources/static/docs/"
+        } else if ("${profile}" == 'release') {
+            destinationDir = "${layout.buildDirectory.dir("resources/main/static/docs/").get()}"
+        }
+
         copy {
             from("${generateSwaggerUISample.outputDir}")
-            into("src/main/resources/static/docs/")
+            into(destinationDir)
         }
     }
 }
 
 bootJar {
-    dependsOn generateSwaggerUISample
-
     ext.profile = (!project.hasProperty('profile') || !profile) ? 'none' : profile
 
-    if ("${profile}" == 'local') {
+    if ("${profile}" == 'local' || "${profile}" == 'release') {
+        dependsOn generateSwaggerUISample
         finalizedBy copySwaggerUISample
     }
 }

--- a/src/main/java/backend/zelkova/config/SecurityConfig.java
+++ b/src/main/java/backend/zelkova/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                     .permitAll();
             authorizeRequests.requestMatchers(HttpMethod.GET, "/posts/**")
                     .permitAll();
-            authorizeRequests.requestMatchers("/roles/**")
+            authorizeRequests.requestMatchers("/roles/**", "/swagger-ui/**")
                     .hasRole("ADMIN");
 
             authorizeRequests.requestMatchers("/docs/**")

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,4 +1,5 @@
 # DB
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/zelkova?characterEncoding=UTF-8&serverTimezone=UTC&profileSQL=true&logger=Slf4JLogger&maxQuerySizeToLog=999999
 spring.datasource.username=root
 spring.datasource.password=1234

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -10,3 +10,6 @@ spring.jpa.properties.hibernate.jdbc.batch_size=100
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
+# swagger
+spring.mvc.static-path-pattern=/swagger-ui/**
+spring.web.resources.static-locations=classpath:/static/docs/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,6 @@
 # jpa
 spring.jpa.open-in-view=false
 spring.jpa.hibernate.ddl-auto=validate
-# DB
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # session
 server.servlet.session.tracking-modes=cookie
 server.servlet.session.timeout=1d

--- a/src/test/java/backend/zelkova/post/controller/PostControllerTest.java
+++ b/src/test/java/backend/zelkova/post/controller/PostControllerTest.java
@@ -240,7 +240,7 @@ class PostControllerTest extends ControllerTestSupport {
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andExpect(status().isNoContent())
-                .andDo(document("writePost",
+                .andDo(document("updatePost",
                         resource(ResourceSnippetParameters.builder()
                                 .summary("글 수정")
                                 .description("글을 수정합니다.")


### PR DESCRIPTION
기본 db를 mysql에서 h2로 변경하였습니다. 이는 develop merge 시 내부 h2를 이용하여 테스트를 동작시킬 것이기 때문입니다.

다만 local, release, master는 실제 배포 환경에 맞는 db인 mysql을 사용할 것이며, release와 master는 실제 테스트 db가 준비되지 않은 경우를 대비하여 도커 컨테이너로 구축할 계획입니다.

그 외에 swagger 경로 및 api 미반영 관련한 점들을 수정했습니다.