### PR TITLE
인증 실패 코드 변경, 리소스 숨김 처리, 카카오 로그인 필드 획득 경로 수정한 PR 올립니다.

### DIFF
--- a/src/main/java/backend/zelkova/account/operator/SocialAccountManager.java
+++ b/src/main/java/backend/zelkova/account/operator/SocialAccountManager.java
@@ -3,6 +3,7 @@ package backend.zelkova.account.operator;
 import backend.zelkova.account.entity.Social;
 import backend.zelkova.account.entity.SocialAccount;
 import backend.zelkova.account.repository.SocialAccountRepository;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -21,10 +22,15 @@ public class SocialAccountManager {
                 .orElseGet(() -> this.supply(social, socialId, attributes));
     }
 
+    @SuppressWarnings("unchecked")
     private SocialAccount supply(Social social, String socialId, Map<String, Object> attributes) {
-        String name = (String) attributes.get("name");
-        String nickname = (String) attributes.get("nickname");
-        String email = (String) attributes.get("email");
+        LinkedHashMap<String, String> properties = (LinkedHashMap<String, String>) attributes.get("properties");
+        LinkedHashMap<String, String> kakaoAccount = (LinkedHashMap<String, String>) attributes.get("kakao_account");
+
+        String name = properties.get("name");
+        String nickname = properties.get("nickname");
+        String email = kakaoAccount.get("email");
+
         return accountSupplier.supply(social, socialId, name, nickname, email);
     }
 }

--- a/src/main/java/backend/zelkova/config/SecurityConfig.java
+++ b/src/main/java/backend/zelkova/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
         });
 
         http.exceptionHandling(exceptionHandleConfig -> exceptionHandleConfig.authenticationEntryPoint(
-                new HttpStatusEntryPoint(HttpStatus.FORBIDDEN)));
+                new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
 
         http.authorizeHttpRequests(authorizeRequests -> {
             authorizeRequests.requestMatchers("/signup", "/login/**", "/oauth2/**")
@@ -96,7 +96,7 @@ public class SecurityConfig {
 
     private AuthenticationFailureHandler authenticationFailureHandler() {
         return (request, response, exception) -> {
-            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType("application/json;charset=UTF-8");
             response.getWriter().write(objectMapper.writeValueAsString(LoginFailureResponse.newInstance(exception)));
         };

--- a/src/main/java/backend/zelkova/config/SecurityConfig.java
+++ b/src/main/java/backend/zelkova/config/SecurityConfig.java
@@ -48,8 +48,11 @@ public class SecurityConfig {
             oauth2Config.failureHandler(authenticationFailureHandler());
         });
 
-        http.exceptionHandling(exceptionHandleConfig -> exceptionHandleConfig.authenticationEntryPoint(
-                new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
+        http.exceptionHandling(exceptionHandleConfig -> {
+            exceptionHandleConfig.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED));
+            exceptionHandleConfig.accessDeniedHandler((request, response, accessDeniedException) ->
+                    response.sendError(HttpServletResponse.SC_NOT_FOUND));
+        });
 
         http.authorizeHttpRequests(authorizeRequests -> {
             authorizeRequests.requestMatchers("/signup", "/login/**", "/oauth2/**")

--- a/src/test/java/backend/zelkova/security/LoginTest.java
+++ b/src/test/java/backend/zelkova/security/LoginTest.java
@@ -69,7 +69,7 @@ class LoginTest extends ControllerTestSupport {
                                 .param("loginId", "loginId")
                                 .param("password", "password")
                 )
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test


### PR DESCRIPTION
인증 실패 시 기존 403 반환에서 401 반환으로 정정합니다.
리소스가 존재하지 않을 시 404, 리소스가 존재하지만 권한이 없을 시 403을 반환했습니다. 이는 리소스의 유무를 판단하게 되는 요소 중 하나가 될 수 있으므로 권한이 없을 때에도 404를 반환하도록 했습니다.
카카오 로그인 시 원하는 필드의 경로가 각각 다릅니다. 따라서 해당 경로 획득에 대해 정정하도록 했습니다.